### PR TITLE
[common] share program extensions

### DIFF
--- a/Eternet.Api.Accounting/src/Eternet.Accounting.Api.sln
+++ b/Eternet.Api.Accounting/src/Eternet.Accounting.Api.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36109.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Accounting.Api", "Eternet.Accounting.Api\Eternet.Accounting.Api.csproj", "{9FBC1757-DB7B-F9C3-3AED-51A724858230}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Api.Common", "..\..\src\Eternet.Api.Common\Eternet.Api.Common.csproj", "{554E5458-37B1-49B1-98DD-1DA7AC562FB3}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Accounting.Contracts", "Eternet.Accounting.Contracts\Eternet.Accounting.Contracts.csproj", "{79DE7A60-BF56-C18F-A89E-D1505EB0C17C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Accounting.Api.Tests", "..\tests\Eternet.Accounting.Api.Tests\Eternet.Accounting.Api.Tests.csproj", "{E340D753-05B1-24B9-4B0F-E9517DE064AE}"
@@ -51,8 +53,16 @@ Global
 		{79DE7A60-BF56-C18F-A89E-D1505EB0C17C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79DE7A60-BF56-C18F-A89E-D1505EB0C17C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{79DE7A60-BF56-C18F-A89E-D1505EB0C17C}.Release|x64.ActiveCfg = Release|Any CPU
-		{79DE7A60-BF56-C18F-A89E-D1505EB0C17C}.Release|x64.Build.0 = Release|Any CPU
-		{E340D753-05B1-24B9-4B0F-E9517DE064AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {79DE7A60-BF56-C18F-A89E-D1505EB0C17C}.Release|x64.Build.0 = Release|Any CPU
+                {554E5458-37B1-49B1-98DD-1DA7AC562FB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {554E5458-37B1-49B1-98DD-1DA7AC562FB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {554E5458-37B1-49B1-98DD-1DA7AC562FB3}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {554E5458-37B1-49B1-98DD-1DA7AC562FB3}.Debug|x64.Build.0 = Debug|Any CPU
+                {554E5458-37B1-49B1-98DD-1DA7AC562FB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {554E5458-37B1-49B1-98DD-1DA7AC562FB3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {554E5458-37B1-49B1-98DD-1DA7AC562FB3}.Release|x64.ActiveCfg = Release|Any CPU
+                {554E5458-37B1-49B1-98DD-1DA7AC562FB3}.Release|x64.Build.0 = Release|Any CPU
+                {E340D753-05B1-24B9-4B0F-E9517DE064AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E340D753-05B1-24B9-4B0F-E9517DE064AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E340D753-05B1-24B9-4B0F-E9517DE064AE}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{E340D753-05B1-24B9-4B0F-E9517DE064AE}.Debug|x64.Build.0 = Debug|Any CPU

--- a/Eternet.Api.Accounting/src/Eternet.Accounting.Api/Configuration/LegacyDbConfig.cs
+++ b/Eternet.Api.Accounting/src/Eternet.Accounting.Api/Configuration/LegacyDbConfig.cs
@@ -1,13 +1,15 @@
+using Eternet.Api.Common;
+
 namespace Eternet.Accounting.Api.Configuration;
 
-public class LegacyDbConfig
+public class LegacyDbConfig : ILegacyDbConfig
 {
-    public bool UseProduction { get; set; } // default is false, so no need to initialize
+    public bool UseProduction { get; set; }
     public LegacyConnectionStringBuilder Testing { get; set; } = new();
     public LegacyConnectionStringBuilder Production { get; set; } = new();
 }
 
-public class LegacyConnectionStringBuilder
+public class LegacyConnectionStringBuilder : ILegacyConnectionStringBuilder
 {
     public string DataSource { get; set; } = string.Empty;
     public string Database { get; set; } = string.Empty;

--- a/Eternet.Api.Accounting/src/Eternet.Accounting.Api/Eternet.Accounting.Api.csproj
+++ b/Eternet.Api.Accounting/src/Eternet.Accounting.Api/Eternet.Accounting.Api.csproj
@@ -60,6 +60,7 @@
 		<ProjectReference Include="..\..\..\Eternet.Web\src\Eternet.Web.Infrastructure\Eternet.Web.Infrastructure.csproj" />-->
 
     <ProjectReference Include="..\Eternet.Accounting.Contracts\Eternet.Accounting.Contracts.csproj" />
-	</ItemGroup>
+    <ProjectReference Include="..\..\..\src\Eternet.Api.Common\Eternet.Api.Common.csproj" />
+        </ItemGroup>
 
 </Project>

--- a/Eternet.Api.Accounting/src/Eternet.Accounting.Api/GlobalUsings.cs
+++ b/Eternet.Api.Accounting/src/Eternet.Accounting.Api/GlobalUsings.cs
@@ -37,3 +37,4 @@ global using Eternet.Accounting.Contracts;
 global using Microsoft.AspNetCore.OData.Query.Expressions;
 global using Eternet.Accounting.Contracts.JournalEntries.Responses;
 global using Eternet.Accounting.Api.Features.VatClosures.Preview.MaterializedViews;
+global using Eternet.Api.Common.Extensions;

--- a/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests.sln
+++ b/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Accounting.Contract
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Accounting.Api", "..\src\Eternet.Accounting.Api\Eternet.Accounting.Api.csproj", "{0388F001-6743-91F3-46CC-9A290607AD3F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Api.Common", "..\..\src\Eternet.Api.Common\Eternet.Api.Common.csproj", "{DD2C88F6-8F7E-4F1A-9DC7-DFB616525C84}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Accounting.Contracts.Tests", "Eternet.Accounting.Contracts.Tests\Eternet.Accounting.Contracts.Tests.csproj", "{63BA3D9F-F2C7-CE11-AC8A-1ADEB0BCF236}"
 EndProject
 Global
@@ -32,8 +34,12 @@ Global
 		{63BA3D9F-F2C7-CE11-AC8A-1ADEB0BCF236}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{63BA3D9F-F2C7-CE11-AC8A-1ADEB0BCF236}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63BA3D9F-F2C7-CE11-AC8A-1ADEB0BCF236}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{63BA3D9F-F2C7-CE11-AC8A-1ADEB0BCF236}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {63BA3D9F-F2C7-CE11-AC8A-1ADEB0BCF236}.Release|Any CPU.Build.0 = Release|Any CPU
+                {DD2C88F6-8F7E-4F1A-9DC7-DFB616525C84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {DD2C88F6-8F7E-4F1A-9DC7-DFB616525C84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {DD2C88F6-8F7E-4F1A-9DC7-DFB616525C84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {DD2C88F6-8F7E-4F1A-9DC7-DFB616525C84}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/Eternet.Accounting.Api.Tests.csproj
+++ b/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/Eternet.Accounting.Api.Tests.csproj
@@ -39,6 +39,7 @@
   <ItemGroup>
 
     <ProjectReference Include="..\..\src\Eternet.Accounting.Api\Eternet.Accounting.Api.csproj" />
+    <ProjectReference Include="..\..\..\src\Eternet.Api.Common\Eternet.Api.Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/ProgramExtensionsTests.cs
+++ b/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/ProgramExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Eternet.Accounting.Api.Configuration;
+using Eternet.Api.Common.Extensions;
 
 namespace Eternet.Accounting.Api.Tests;
 

--- a/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api.sln
+++ b/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36109.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Purchasing.Api", "Eternet.Purchasing.Api\Eternet.Purchasing.Api.csproj", "{37DC3CB0-A822-1750-293F-290C51779AD2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Api.Common", "..\..\src\Eternet.Api.Common\Eternet.Api.Common.csproj", "{0CDFA19E-A7FD-4A27-9567-5685C562F10F}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Purchasing.Contracts", "Eternet.Purchasing.Contracts\Eternet.Purchasing.Contracts.csproj", "{4D180352-18D8-CBDC-7C70-5B995A16A4C2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eternet.Purchasing.Api.Tests", "..\tests\Eternet.Purchasing.Api.Tests\Eternet.Purchasing.Api.Tests.csproj", "{AB25D19E-419A-21BD-7561-72FB394BC1B0}"
@@ -46,9 +48,17 @@ Global
 		{AB25D19E-419A-21BD-7561-72FB394BC1B0}.Debug|x64.Build.0 = Debug|Any CPU
 		{AB25D19E-419A-21BD-7561-72FB394BC1B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AB25D19E-419A-21BD-7561-72FB394BC1B0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{AB25D19E-419A-21BD-7561-72FB394BC1B0}.Release|x64.ActiveCfg = Release|Any CPU
-		{AB25D19E-419A-21BD-7561-72FB394BC1B0}.Release|x64.Build.0 = Release|Any CPU
-		{CFE8C862-4AF2-427E-AFA1-6AA570CD9CD7}.Debug|Any CPU.ActiveCfg = Debug|x64
+                {AB25D19E-419A-21BD-7561-72FB394BC1B0}.Release|x64.ActiveCfg = Release|Any CPU
+                {AB25D19E-419A-21BD-7561-72FB394BC1B0}.Release|x64.Build.0 = Release|Any CPU
+                {0CDFA19E-A7FD-4A27-9567-5685C562F10F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0CDFA19E-A7FD-4A27-9567-5685C562F10F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0CDFA19E-A7FD-4A27-9567-5685C562F10F}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {0CDFA19E-A7FD-4A27-9567-5685C562F10F}.Debug|x64.Build.0 = Debug|Any CPU
+                {0CDFA19E-A7FD-4A27-9567-5685C562F10F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0CDFA19E-A7FD-4A27-9567-5685C562F10F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {0CDFA19E-A7FD-4A27-9567-5685C562F10F}.Release|x64.ActiveCfg = Release|Any CPU
+                {0CDFA19E-A7FD-4A27-9567-5685C562F10F}.Release|x64.Build.0 = Release|Any CPU
+                {CFE8C862-4AF2-427E-AFA1-6AA570CD9CD7}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{CFE8C862-4AF2-427E-AFA1-6AA570CD9CD7}.Debug|Any CPU.Build.0 = Debug|x64
 		{CFE8C862-4AF2-427E-AFA1-6AA570CD9CD7}.Debug|Any CPU.Deploy.0 = Debug|x64
 		{CFE8C862-4AF2-427E-AFA1-6AA570CD9CD7}.Debug|x64.ActiveCfg = Debug|x64

--- a/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api/Configuration/LegacyDbConfig.cs
+++ b/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api/Configuration/LegacyDbConfig.cs
@@ -1,13 +1,15 @@
-﻿namespace Eternet.Purchasing.Api.Configuration;
+﻿using Eternet.Api.Common;
 
-public class LegacyDbConfig
+namespace Eternet.Purchasing.Api.Configuration;
+
+public class LegacyDbConfig : ILegacyDbConfig
 {
     public bool UseProduction { get; set; } = false;
     public LegacyConnectionStringBuilder Testing { get; set; } = new();
     public LegacyConnectionStringBuilder Production { get; set; } = new();
 }
 
-public class LegacyConnectionStringBuilder
+public class LegacyConnectionStringBuilder : ILegacyConnectionStringBuilder
 {
     public string DataSource { get; set; } = string.Empty;
     public string Database { get; set; } = string.Empty;
@@ -16,5 +18,6 @@ public class LegacyConnectionStringBuilder
     public string Charset { get; set; } = string.Empty;
     public bool Pooling { get; set; }
     public bool LogEntityFramework { get; set; } = true;
+    public int ConnectionLifeTime { get; set; }
     public int Port { get; set; }
 }

--- a/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api/Eternet.Purchasing.Api.csproj
+++ b/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api/Eternet.Purchasing.Api.csproj
@@ -30,8 +30,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Eternet.Web.Infrastructure" Version="1.0.7" />
-		<!-- /Eternet -->
+    <PackageReference Include="Eternet.Web.Infrastructure" Version="1.0.7" />
+    <!-- /Eternet -->
 
 		<PackageReference Include="Microsoft.AspNetCore.OData" Version="9.3.1" />
 		
@@ -46,7 +46,8 @@
 		<ProjectReference Include="..\..\..\..\..\Eternet.AspNetCore\src\Eternet.Mediator\Eternet.Mediator.Generator\Eternet.Mediator.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\..\..\..\..\Eternet.Web\src\Eternet.Web.Infrastructure\Eternet.Web.Infrastructure.csproj" />
 		-->
-		<ProjectReference Include="..\Eternet.Purchasing.Contracts\Eternet.Purchasing.Contracts.csproj" />
-	</ItemGroup>
+        <ProjectReference Include="..\Eternet.Purchasing.Contracts\Eternet.Purchasing.Contracts.csproj" />
+        <ProjectReference Include="..\..\..\src\Eternet.Api.Common\Eternet.Api.Common.csproj" />
+        </ItemGroup>
 
 </Project>

--- a/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api/GlobalUsings.cs
+++ b/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api/GlobalUsings.cs
@@ -5,3 +5,4 @@ global using Eternet.Purchasing.Api;
 global using Eternet.Purchasing.Api.Model;
 global using Eternet.Purchasing.Api.Model.Configurations;
 global using Eternet.Crud.Relational.Attributes;
+global using Eternet.Api.Common.Extensions;

--- a/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api/ProgramExtensions.cs
+++ b/Eternet.Api.Purchasing/src/Eternet.Purchasing.Api/ProgramExtensions.cs
@@ -82,7 +82,7 @@ public static class ProgramExtensions
         services.AddSingleton<ILegacyContextFabric, LegacyContextFabric>();
         services.AddHttpContextAccessor();
         services.AddScoped<IEnvironmentService, EnvironmentService>();
-        services.AddConnectionStringBuilder();
+        services.AddConnectionStringBuilder<LegacyDbConfig>();
         services.AddScoped(s =>
         {
             var legacyDbConfig = s.GetRequiredService<IOptions<LegacyDbConfig>>();
@@ -101,11 +101,8 @@ public static class ProgramExtensions
 
     public static void UseAppMiddlewares(this WebApplication app)
     {
-        app.UseSharedSwaggerUI(
-            serviceFabricPath: "Eternet.Api.Modules/Eternet.Purchasing.Api",
-            useServiceFabric: ServiceFabricUtils.IsHosted);
-        app.MapControllers();
-        //app.MapEternetPrometheusScrapingEndpoint();
+        app.UseAppMiddlewares(
+            serviceFabricPath: "Eternet.Api.Modules/Eternet.Purchasing.Api");
     }
 
     private static void AddConfigurations(this IServiceCollection services, IConfiguration configuration)
@@ -113,39 +110,5 @@ public static class ProgramExtensions
         services.Configure<LegacyDbConfig>(configuration.GetSection(nameof(LegacyDbConfig)));
     }
 
-    private static IServiceCollection AddConnectionStringBuilder(this IServiceCollection services)
-    {
-        return services.AddTransient(s =>
-        {
-            var service = s.GetRequiredService<IOptions<LegacyDbConfig>>();
-            var connBuilder = service.Value;
-            var envService = s.GetRequiredService<IEnvironmentService>();
-            var env = envService.GetEnvironment();
-            if (env == ApiEnvironment.Testing)
-            {
-                return connBuilder.Testing.CreateConnectionBuilder();
-            }
 
-            if (connBuilder.UseProduction)
-            {
-                return connBuilder.Production.CreateConnectionBuilder();
-            }
-
-            return connBuilder.Testing.CreateConnectionBuilder();
-        });
-    }
-
-    public static FbConnectionStringBuilder CreateConnectionBuilder(this LegacyConnectionStringBuilder connBuilder)
-    {
-        return new FbConnectionStringBuilder
-        {
-            DataSource = connBuilder.DataSource,
-            Database = connBuilder.Database,
-            UserID = connBuilder.UserId,
-            Password = connBuilder.Password,
-            Charset = connBuilder.Charset,
-            Pooling = connBuilder.Pooling,
-            Port = connBuilder.Port
-        };
-    }
 }

--- a/src/Eternet.Api.Common/Eternet.Api.Common.csproj
+++ b/src/Eternet.Api.Common/Eternet.Api.Common.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="9.6.1" />
+    <PackageReference Include="Eternet.AspNetCore.ServiceFabric" Version="9.0.4" />
+    <PackageReference Include="Eternet.Web.Infrastructure" Version="1.0.8" />
+  </ItemGroup>
+</Project>

--- a/src/Eternet.Api.Common/Extensions/ConnectionStringExtensions.cs
+++ b/src/Eternet.Api.Common/Extensions/ConnectionStringExtensions.cs
@@ -1,0 +1,21 @@
+using FirebirdSql.Data.FirebirdClient;
+
+namespace Eternet.Api.Common.Extensions;
+
+public static class ConnectionStringExtensions
+{
+    public static FbConnectionStringBuilder CreateConnectionBuilder(this ILegacyConnectionStringBuilder builder)
+    {
+        return new FbConnectionStringBuilder
+        {
+            DataSource = builder.DataSource,
+            Database = builder.Database,
+            UserID = builder.UserId,
+            Password = builder.Password,
+            Charset = builder.Charset,
+            Pooling = builder.Pooling,
+            ConnectionLifeTime = builder.ConnectionLifeTime,
+            Port = builder.Port
+        };
+    }
+}

--- a/src/Eternet.Api.Common/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Eternet.Api.Common/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using Eternet.Api.Common;
+using Eternet.Web.Infrastructure.Environment;
+using Microsoft.Extensions.Options;
+using FirebirdSql.Data.FirebirdClient;
+
+namespace Eternet.Api.Common.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddConnectionStringBuilder<TConfig>(this IServiceCollection services, bool ignoreUseProduction = false)
+        where TConfig : class, ILegacyDbConfig
+    {
+        return services.AddTransient(provider =>
+        {
+            var options = provider.GetRequiredService<IOptions<TConfig>>();
+            var envService = provider.GetRequiredService<IEnvironmentService>();
+            var env = envService.GetEnvironment();
+            var config = options.Value;
+
+            if (env == ApiEnvironment.Testing)
+            {
+                return config.Testing.CreateConnectionBuilder();
+            }
+
+            if (!ignoreUseProduction && !config.UseProduction)
+            {
+                return config.Testing.CreateConnectionBuilder();
+            }
+
+            return config.Production.CreateConnectionBuilder();
+        });
+    }
+}

--- a/src/Eternet.Api.Common/Extensions/SwaggerExtensions.cs
+++ b/src/Eternet.Api.Common/Extensions/SwaggerExtensions.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using Eternet.Web.Infrastructure.Swagger;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Eternet.Api.Common.Extensions;
+
+public static class SwaggerExtensions
+{
+    public static void AddCustomSwagger(this IServiceCollection services)
+    {
+        services.AddSwaggerGen(c =>
+        {
+            c.SupportNonNullableReferenceTypes();
+            c.UseAllOfToExtendReferenceSchemas();
+            c.SchemaFilter<RequiredNotNullableSchemaFilter>();
+            c.DocumentFilter<EnvHeaderDocumentFilter>(EnvType.Test);
+            c.MapTimeSpan();
+            c.MapTimeOnly();
+            c.OperationFilter<ReadGeneratedCodeAttributesOperationFilter>();
+            var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+            var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+            c.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
+            c.OperationFilter<RemoveODataMediaTypesFilter>();
+        });
+    }
+}
+
+public class ReadGeneratedCodeAttributesOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var meta = context.ApiDescription.ActionDescriptor.EndpointMetadata
+                          .OfType<IEndpointSummaryMetadata>()
+                          .FirstOrDefault();
+
+        if (meta is not null && string.IsNullOrEmpty(operation.Summary))
+        {
+            operation.Summary = meta.Summary;
+        }
+    }
+}

--- a/src/Eternet.Api.Common/Extensions/WebApplicationExtensions.cs
+++ b/src/Eternet.Api.Common/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,17 @@
+using Eternet.AspNetCore.ServiceFabric;
+using Microsoft.AspNetCore.Builder;
+
+namespace Eternet.Api.Common.Extensions;
+
+public static class WebApplicationExtensions
+{
+    public static void UseAppMiddlewares(this WebApplication app, string serviceFabricPath, bool mapDefaultEndpoints = false)
+    {
+        app.UseSharedSwaggerUI(serviceFabricPath: serviceFabricPath, useServiceFabric: ServiceFabricUtils.IsHosted);
+        app.MapControllers();
+        if (mapDefaultEndpoints)
+        {
+            app.MapDefaultEndpoints();
+        }
+    }
+}

--- a/src/Eternet.Api.Common/ILegacyDbConfig.cs
+++ b/src/Eternet.Api.Common/ILegacyDbConfig.cs
@@ -1,0 +1,20 @@
+namespace Eternet.Api.Common;
+
+public interface ILegacyConnectionStringBuilder
+{
+    string DataSource { get; }
+    string Database { get; }
+    string UserId { get; }
+    string Password { get; }
+    string Charset { get; }
+    bool Pooling { get; }
+    int ConnectionLifeTime { get; }
+    int Port { get; }
+}
+
+public interface ILegacyDbConfig
+{
+    bool UseProduction { get; }
+    ILegacyConnectionStringBuilder Testing { get; }
+    ILegacyConnectionStringBuilder Production { get; }
+}


### PR DESCRIPTION
## Summary
- introduce `Eternet.Api.Common` with shared extension methods
- deduplicate `ProgramExtensions` in Accounting and Purchasing APIs
- update configs to implement new interfaces
- reference `Eternet.Api.Common` from API projects and tests

## Testing
- `dotnet build tests/Eternet.Accounting.Api.Tests.sln -c Release --no-restore` *(fails: project.assets.json not found)*
- `dotnet test Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests.sln --no-build --no-restore` *(fails: Invalid TargetPath)*