### PR TITLE
[tests] introduce shared utilities

### DIFF
--- a/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/Eternet.Accounting.Api.Tests.csproj
+++ b/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/Eternet.Accounting.Api.Tests.csproj
@@ -27,6 +27,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\tests\Eternet.Testing\Eternet.Testing.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
     <PackageReference Include="FirebirdDb.Embedded.V3.NativeAssets.Windows.X64" Version="1.0.6" PrivateAssets="all" />
   </ItemGroup>

--- a/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/Features/Journal/CreateEntry/CreateEntryAccountingJournalTests.cs
+++ b/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/Features/Journal/CreateEntry/CreateEntryAccountingJournalTests.cs
@@ -59,6 +59,6 @@ public class CreateEntryAccountingJournalTests()
 
         // Act
         var result = await mediator.Send(command, TestContext.Current.CancellationToken);
-        result.IsDomainResult.Should().BeTrue(result.GetErrorMessage());
+        result.ShouldBeSuccess();
     }
 }

--- a/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/GlobalUsings.cs
+++ b/Eternet.Api.Accounting/tests/Eternet.Accounting.Api.Tests/GlobalUsings.cs
@@ -1,2 +1,3 @@
 global using FluentAssertions;
 global using Xunit;
+global using Eternet.Testing.Assertions;

--- a/Eternet.Api.Purchasing/tests/Eternet.Purchasing.Api.Tests/Eternet.Purchasing.Api.Tests.csproj
+++ b/Eternet.Api.Purchasing/tests/Eternet.Purchasing.Api.Tests/Eternet.Purchasing.Api.Tests.csproj
@@ -18,13 +18,17 @@
 	  <None Remove="Features\**" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="AutoFixture.AutoNSubstitute" />
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoNSubstitute" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
 		<PackageReference Include="AwesomeAssertions" />
 		<PackageReference Include="Testcontainers" />
-		<PackageReference Include="System.ComponentModel.TypeConverter" />
-	</ItemGroup>
+    <PackageReference Include="System.ComponentModel.TypeConverter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\tests\Eternet.Testing\Eternet.Testing.csproj" />
+  </ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\Eternet.Purchasing.Api\Eternet.Purchasing.Api.csproj" />

--- a/Eternet.Api.Purchasing/tests/Eternet.Purchasing.Api.Tests/GlobalUsings.cs
+++ b/Eternet.Api.Purchasing/tests/Eternet.Purchasing.Api.Tests/GlobalUsings.cs
@@ -1,3 +1,4 @@
-﻿global using AutoFixture;
+global using AutoFixture;
 global using FluentAssertions;
 global using Xunit;
+global using Eternet.Testing.Assertions;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Codex Modules API
+
+This repository hosts several Eternet API modules. Tests share utilities provided by the `Eternet.Testing` library placed under `tests/`.
+
+## Reusing test utilities
+
+When creating a new module with its own test project:
+
+1. Add a project reference to `tests/Eternet.Testing/Eternet.Testing.csproj`.
+2. Import the global usings with `global using Eternet.Testing.Assertions;` or other namespaces as needed.
+3. Use `ApiWebApplicationFactory<TProgram>` to bootstrap a test host.
+4. Use `FixtureFactory.Create()` to get a preconfigured AutoFixture instance.
+5. Call `result.ShouldBeSuccess()` to verify domain results.
+
+These helpers avoid duplicating setup code across modules and keep tests consistent.

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="xunit.v3" Version="2.0.2" />
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
+  </ItemGroup>
+</Project>

--- a/tests/Eternet.Testing/Assertions/DomainResultAssertions.cs
+++ b/tests/Eternet.Testing/Assertions/DomainResultAssertions.cs
@@ -1,0 +1,14 @@
+using FluentAssertions;
+
+namespace Eternet.Testing.Assertions;
+
+public static class DomainResultAssertions
+{
+    public static void ShouldBeSuccess(this object result)
+    {
+        var type = result.GetType();
+        var isSuccess = (bool?)type.GetProperty("IsDomainResult")?.GetValue(result) ?? false;
+        var message = type.GetMethod("GetErrorMessage")?.Invoke(result, null) as string;
+        isSuccess.Should().BeTrue(message);
+    }
+}

--- a/tests/Eternet.Testing/Eternet.Testing.csproj
+++ b/tests/Eternet.Testing/Eternet.Testing.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoNSubstitute" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+</Project>

--- a/tests/Eternet.Testing/Fixtures/FixtureFactory.cs
+++ b/tests/Eternet.Testing/Fixtures/FixtureFactory.cs
@@ -1,0 +1,14 @@
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+
+namespace Eternet.Testing.Fixtures;
+
+public static class FixtureFactory
+{
+    public static Fixture Create()
+    {
+        var fixture = new Fixture();
+        fixture.Customize(new AutoNSubstituteCustomization { ConfigureMembers = true });
+        return fixture;
+    }
+}

--- a/tests/Eternet.Testing/Web/ApiWebApplicationFactory.cs
+++ b/tests/Eternet.Testing/Web/ApiWebApplicationFactory.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Eternet.Testing.Web;
+
+public class ApiWebApplicationFactory<TProgram> : WebApplicationFactory<TProgram>
+    where TProgram : class
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+    }
+}


### PR DESCRIPTION
## Summary
- add Eternet.Testing project with reusable test helpers
- reference the new utilities from Accounting and Purchasing tests
- simplify journal entry test with `ShouldBeSuccess`
- document how to reuse the library in the README

## Testing
- `dotnet build tests/Eternet.Accounting.Api.Tests.sln -c Release --no-restore --verbosity minimal` *(fails: unexpected logger failure)*
- `dotnet test tests/Eternet.Accounting.Api.Tests.sln --no-build --no-restore --verbosity minimal` *(fails: invalid target path)*
- `dotnet build tests/Eternet.Purchasing.Api.Tests/Eternet.Purchasing.Api.Tests.csproj -c Release --no-restore --verbosity minimal` *(fails: unexpected logger failure)*