### PR TITLE
[template] expand web api service template

### DIFF
--- a/Eternet.Service.Template/Eternet.WebApiService.Template.csproj
+++ b/Eternet.Service.Template/Eternet.WebApiService.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <PackageId>Eternet.WebApiService.Template</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <PackageType>Template</PackageType>
     <Description>Eternet Web API Service project template.</Description>
     <PackageTags>template;service;eternet</PackageTags>

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService.Api.sln
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService.Api.sln
@@ -1,0 +1,70 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36109.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateService.Api", "TemplateService.Api\TemplateService.Api.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateService.Contracts", "TemplateService.Contracts\TemplateService.Contracts.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TemplateService.Api.Tests", "..\tests\TemplateService.Api.Tests\TemplateService.Api.Tests.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Project("{A07B5EB6-E848-4116-A8D0-A826331D98C6}") = "TemplateService", "TemplateService\TemplateService.sfproj", "{00000000-0000-0000-0000-000000000000}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{089100B1-113F-4E66-888A-E83F3999EAFD}"
+	ProjectSection(SolutionItems) = preProject
+		..\.gitignore = ..\.gitignore
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|x64.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|x64.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|x64.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|x64.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|x64.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|x64.Build.0 = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|x64.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|x64.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|x64.Build.0 = Release|Any CPU
+		{00000000-0000-0000-0000-000000000000}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{00000000-0000-0000-0000-000000000000}.Debug|Any CPU.Build.0 = Debug|x64
+		{00000000-0000-0000-0000-000000000000}.Debug|Any CPU.Deploy.0 = Debug|x64
+		{00000000-0000-0000-0000-000000000000}.Debug|x64.ActiveCfg = Debug|x64
+		{00000000-0000-0000-0000-000000000000}.Debug|x64.Build.0 = Debug|x64
+		{00000000-0000-0000-0000-000000000000}.Debug|x64.Deploy.0 = Debug|x64
+		{00000000-0000-0000-0000-000000000000}.Release|Any CPU.ActiveCfg = Release|x64
+		{00000000-0000-0000-0000-000000000000}.Release|Any CPU.Build.0 = Release|x64
+		{00000000-0000-0000-0000-000000000000}.Release|Any CPU.Deploy.0 = Release|x64
+		{00000000-0000-0000-0000-000000000000}.Release|x64.ActiveCfg = Release|x64
+		{00000000-0000-0000-0000-000000000000}.Release|x64.Build.0 = Release|x64
+		{00000000-0000-0000-0000-000000000000}.Release|x64.Deploy.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {44444444-4444-4444-4444-444444444444}
+	EndGlobalSection
+EndGlobal

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService.Contracts/GlobalUsings.cs
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService.Contracts/GlobalUsings.cs
@@ -1,0 +1,7 @@
+global using FluentValidation;
+
+global using Eternet.Mediator;
+
+global using Eternet.Mediator.Abstractions.Handlers;
+
+global using Eternet.Mediator.Abstractions.Responses;

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService.Contracts/Sample/Config.cs
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService.Contracts/Sample/Config.cs
@@ -1,0 +1,6 @@
+namespace TemplateService.Contracts.Sample;
+
+public static class Config
+{
+    public const string ControllerName = "sample";
+}

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService.Contracts/Sample/SampleResponses.cs
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService.Contracts/Sample/SampleResponses.cs
@@ -1,0 +1,3 @@
+namespace TemplateService.Contracts.Sample;
+
+public record SampleResponse(int Id);

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService.Contracts/TemplateService.Contracts.csproj
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService.Contracts/TemplateService.Contracts.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Eternet.Mediator" Version="1.2.0" />
+  </ItemGroup>
+</Project>

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService/ApplicationParameters/Cloud.xml
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService/ApplicationParameters/Cloud.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Application xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="fabric:/TemplateService" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+  <Parameters />
+</Application>

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService/PublishProfiles/Cloud.xml
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService/PublishProfiles/Cloud.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PublishProfile xmlns="http://schemas.microsoft.com/2015/05/fabrictools">
+    <ClusterConnectionParameters ConnectionEndpoint="servicefabric.example.com:19000" />
+    <ApplicationParameterFile Path="..\ApplicationParameters\Cloud.xml" />
+    <StartupServiceParameterFile Path="..\StartupServiceParameters\Cloud.xml" />
+    <CopyPackageParameters CompressPackage="true" />
+</PublishProfile>

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService/Scripts/Deploy-FabricApplication.ps1
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService/Scripts/Deploy-FabricApplication.ps1
@@ -1,0 +1,36 @@
+<#
+.SYNOPSIS
+Deploys a Service Fabric application type to a cluster.
+#>
+
+param (
+    [string]$PublishProfileFile,
+    [string]$StartupServicesFile,
+    [string]$ApplicationPackagePath,
+    [switch]$DeployOnly,
+    [string]$OverwriteBehavior = 'SameAppTypeAndVersion'
+)
+
+$publishProfile = Get-Content $PublishProfileFile | ConvertFrom-Xml
+$PublishParameters = @{
+    PublishProfileFile = $PublishProfileFile
+    ApplicationPackagePath = $ApplicationPackagePath
+    OverwriteBehavior = $OverwriteBehavior
+    SkipPackageValidation = $true
+}
+
+if ($StartupServicesFile) {
+    $PublishParameters['StartupServicesFilePath'] = $StartupServicesFile
+    if ($publishProfile.PublishProfile.StartupServiceParameterFile) {
+        $PublishParameters['StartupServiceParameterFilePath'] = $publishProfile.PublishProfile.StartupServiceParameterFile
+    }
+}
+
+$Action = 'RegisterAndCreate'
+if ($DeployOnly) {
+    $Action = 'Register'
+}
+
+$PublishParameters['Action'] = $Action
+
+Publish-NewServiceFabricApplication @PublishParameters

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService/StartupServiceParameters/Cloud.xml
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService/StartupServiceParameters/Cloud.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StartupServices xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+  <Parameters />
+</StartupServices>

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService/StartupServices.xml
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService/StartupServices.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<StartupServicesManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+  <Parameters>
+    <Parameter Name="TemplateService.Api_InstanceCount" DefaultValue="1" />
+  </Parameters>
+  <Services>
+    <Service Name="TemplateService.Api" ServicePackageActivationMode="ExclusiveProcess">
+      <StatelessService ServiceTypeName="TemplateService.ApiType" InstanceCount="[TemplateService.Api_InstanceCount]">
+        <SingletonPartition />
+      </StatelessService>
+    </Service>
+  </Services>
+</StartupServicesManifest>

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService/TemplateService.sfproj
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService/TemplateService.sfproj
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>00000000-0000-0000-0000-000000000000</ProjectGuid>
+    <ProjectVersion>2.7</ProjectVersion>
+    <MinToolsVersion>16.10</MinToolsVersion>
+    <SupportedMSBuildNuGetPackageVersion>1.7.9</SupportedMSBuildNuGetPackageVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="ApplicationPackageRoot\ApplicationManifest.xml" />
+    <None Include="ApplicationParameters\Cloud.xml" />
+    <None Include="PublishProfiles\Cloud.xml" />
+    <None Include="Scripts\Deploy-FabricApplication.ps1" />
+    <None Include="StartupServiceParameters\Cloud.xml" />
+    <None Include="StartupServices.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TemplateService.Api\TemplateService.Api.csproj" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+  <PropertyGroup>
+    <ApplicationProjectTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Service Fabric Tools\Microsoft.VisualStudio.Azure.Fabric.ApplicationProject.targets</ApplicationProjectTargetsPath>
+  </PropertyGroup>
+  <Import Project="$(ApplicationProjectTargetsPath)" Condition="Exists('$(ApplicationProjectTargetsPath)')" />
+  <Import Project="..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" />
+  <Target Name="ValidateMSBuildFiles" BeforeTargets="PrepareForBuild">
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.props' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets')" Text="Unable to find the '..\packages\Microsoft.VisualStudio.Azure.Fabric.MSBuild.1.7.9\build\Microsoft.VisualStudio.Azure.Fabric.Application.targets' file. Please restore the 'Microsoft.VisualStudio.Azure.Fabric.MSBuild' Nuget package." />
+  </Target>
+</Project>

--- a/Eternet.Service.Template/content/TemplateService/src/TemplateService/packages.config
+++ b/Eternet.Service.Template/content/TemplateService/src/TemplateService/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.VisualStudio.Azure.Fabric.MSBuild" version="1.7.9" targetFramework="net48" />
+</packages>

--- a/Eternet.Service.Template/content/TemplateService/tests/Directory.Build.props
+++ b/Eternet.Service.Template/content/TemplateService/tests/Directory.Build.props
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio" />
+		<PackageReference Include="Verify.XunitV3" />
+		<PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+	</ItemGroup>
+</Project>

--- a/Eternet.Service.Template/content/TemplateService/tests/Directory.Build.targets
+++ b/Eternet.Service.Template/content/TemplateService/tests/Directory.Build.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/Eternet.Service.Template/content/TemplateService/tests/Directory.Packages.props
+++ b/Eternet.Service.Template/content/TemplateService/tests/Directory.Packages.props
@@ -1,0 +1,24 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="xunit.v3" Version="2.0.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.1.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageVersion Include="FluentAssertions" Version="[7.0.0]" />
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
+    <PackageVersion Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageVersion Include="Testcontainers" Version="4.4.0" />
+    <PackageVersion Include="WireMock.Net" Version="1.7.4" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+  </ItemGroup>
+</Project>

--- a/Eternet.Service.Template/content/TemplateService/tests/TemplateService.Api.Tests/TemplateService.Api.Tests.csproj
+++ b/Eternet.Service.Template/content/TemplateService/tests/TemplateService.Api.Tests/TemplateService.Api.Tests.csproj
@@ -1,12 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <Compile Remove="Common\**" />
+    <Compile Remove="Features\**" />
+    <EmbeddedResource Remove="Common\**" />
+    <EmbeddedResource Remove="Features\**" />
+    <None Remove="Common\**" />
+    <None Remove="Features\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoFixture.AutoNSubstitute" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\TemplateService.Api\TemplateService.Api.csproj" />


### PR DESCRIPTION
## Summary
- expand `Eternet.WebApiService.Template` to mimic real service layout
- add solution file, contracts project and Service Fabric project
- include test infrastructure files
- bump template version to 1.1.0

## Testing
- `dotnet build Eternet.Service.Template/Eternet.WebApiService.Template.csproj -c Release --no-restore --verbosity minimal` *(fails: NETSDK1004)*